### PR TITLE
Fix error when not company found

### DIFF
--- a/lib/core/generator.js
+++ b/lib/core/generator.js
@@ -113,10 +113,12 @@ function generateHTML (pages) {
     const outputPath = build(
       product.path,
       product.presskit,
+      pages.company ?
       {
         company: pages.company.presskit,
         analytics
       }
+      : {}
     )
 
     productsList.push({path: outputPath, title: product.presskit.title})


### PR DESCRIPTION
Fix following error : 
```
λ presskit ..\product-presskit\
Starting directory: ..\product-presskit\

Finding data…
- product: "My Super Game" ..\product-presskit\data.xml

Generating HTML…
C:\Users\Coac\Documents\Projects\presskit\lib\core\generator.js:119
        company: pages.company.presskit,
                              ^

TypeError: Cannot read property 'presskit' of undefined
    at generateHTML (C:\Users\Coac\Documents\Projects\presskit\lib\core\generator.js:119:31)
    at Object.generate (C:\Users\Coac\Documents\Projects\presskit\lib\core\generator.js:36:3)
    at parseEntryPoint (C:\Users\Coac\Documents\Projects\presskit\lib\index.js:30:15)
    at fs.stat (C:\Users\Coac\Documents\Projects\presskit\lib\index.js:48:7)
    at FSReqWrap.oncomplete (fs.js:153:5)
```
occured when using `presskit ..\product-presskit\` on a folder containing only one product and no company.