### PR TITLE
Fix video and articles anchor links in navigation

### DIFF
--- a/assets/_includes/nav.html
+++ b/assets/_includes/nav.html
@@ -52,7 +52,7 @@
 
     {{#if presskit.trailers}}
     <li>
-      <a class="nav__item" href="#trailers">Videos</a>
+      <a class="nav__item" href="#videos">Videos</a>
     </li>
     {{/if}}
 
@@ -82,7 +82,7 @@
 
     {{#if presskit.quotes}}
     <li>
-      <a class="nav__item" href="#quotes">Selected Articles</a>
+      <a class="nav__item" href="#articles">Selected Articles</a>
     </li>
     {{/if}}
 


### PR DESCRIPTION
The anchor links for Videos and Selected Articles are using wrong anchor names.