### PR TITLE
Add Game Jolt widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ This is a new feature of **presskit.html**: you can put your widgets directly in
 - Steam `<steam>STEAM_ID</steam>`
 - Humble Bundle `<humble>product_name/BUNDLE_ID</humble>`
 - Itch.io `<itch>ITCH_ID</itch>`
+- Game Jolt `<gamejolt>PACKAGE_ID</gamejolt>`
 - Bandcamp `<bandcamp>BANDCAMP_ID</bandcamp>`
 
 Just add the `<widgets>` tag, and the widget providers that you want:
@@ -249,6 +250,7 @@ Just add the `<widgets>` tag, and the widget providers that you want:
   <steam>347160</steam>
   <humble>steredenn/7SDLfk23hw</humble>
   <itch>27992</itch>
+  <gamejolt>8ReMi2Nw</gamejolt>
   <bandcamp>1135613467</bandcamp>
 </widgets>
 ```

--- a/assets/_includes/widgets.html
+++ b/assets/_includes/widgets.html
@@ -44,6 +44,12 @@
   </p>
   {{/if}}
 
+  {{#if presskit.widgets.gamejolt}}
+  <p>
+    <iframe src="https://widgets.gamejolt.com/package/v1?key={{trim presskit.widgets.gamejolt}}" frameborder="0" class="widget widget--gamejolt"></iframe>
+  </p>
+  {{/if}}
+
   {{#if presskit.widgets.bandcamp}}
   <p>
     <!-- TODO: customize `linkcol` with brand color. -->

--- a/assets/css/master.css
+++ b/assets/css/master.css
@@ -462,6 +462,10 @@ a:hover {
   height: 167px;
 }
 
+.widget--gamejolt {
+  height: 245px;
+}
+
 .widget--bandcamp {
   width: 100%;
   height: 120px;

--- a/assets/templates/product.xml
+++ b/assets/templates/product.xml
@@ -68,6 +68,10 @@
       <!-- itch.io ID -->
       <!-- e.g. 42424 -->
     </itch>
+    <gamejolt>
+      <!-- GameJolt package ID -->
+      <!-- e.g. 4AbCd2Ef -->
+    </gamejolt>
     <bandcamp>
       <!-- Bandcamp ID -->
       <!-- e.g. 4242424242 -->

--- a/assets/templates/product.xml
+++ b/assets/templates/product.xml
@@ -69,7 +69,7 @@
       <!-- e.g. 42424 -->
     </itch>
     <gamejolt>
-      <!-- GameJolt package ID -->
+      <!-- Game Jolt package ID -->
       <!-- e.g. 4AbCd2Ef -->
     </gamejolt>
     <bandcamp>


### PR DESCRIPTION
Allows [Game Jolt](https://gamejolt.com/) games to be embedded via a widget.