### PR TITLE
Use https for steam widget

### DIFF
--- a/assets/_includes/widgets.html
+++ b/assets/_includes/widgets.html
@@ -28,7 +28,7 @@
 
   {{#if presskit.widgets.steam}}
   <p>
-    <iframe src="http://store.steampowered.com/widget/{{trim presskit.widgets.steam}}/" frameborder="0" class="widget widget--steam"></iframe>
+    <iframe src="https://store.steampowered.com/widget/{{trim presskit.widgets.steam}}/" frameborder="0" class="widget widget--steam"></iframe>
   </p>
   {{/if}}
 


### PR DESCRIPTION
This is mainly to stop `Blocked loading mixed active content` when serving only https content.